### PR TITLE
Fix for https://bugs.openjdk.org/browse/JDK-8246204

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		     mvn versions:display-dependency-updates
 
 		     to check for updates for these below -->
-		<javafx.version>19</javafx.version>
+		<javafx.version>19.0.2</javafx.version>
 		<mmtf.version>1.0.10</mmtf.version>
 		<openchemlib.version>2021.10.1</openchemlib.version>
 		<janino.version>2.7.4</janino.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		     mvn versions:display-dependency-updates
 
 		     to check for updates for these below -->
-		<javafx.version>11.0.2</javafx.version>
+		<javafx.version>19</javafx.version>
 		<mmtf.version>1.0.10</mmtf.version>
 		<openchemlib.version>2021.10.1</openchemlib.version>
 		<janino.version>2.7.4</janino.version>


### PR DESCRIPTION
Compiling via Maven and with javafx version 11.0.2, I do not see the graphical  output of a molecule in the builder. Running with -Dprism.verbose=true gives more detail:

```
Prism pipeline init order: es2 sw 
Using Double Precision Marlin Rasterizer
Using dirty region optimizations
Not using texture mask for primitives
Not forcing power of 2 sizes for textures
Using hardware CLAMP_TO_ZERO mode
Opting in for HiDPI pixel scaling
Prism pipeline name = com.sun.prism.es2.ES2Pipeline
Loading ES2 native library ... prism_es2
	succeeded.
GLFactory using com.sun.prism.es2.X11GLFactory
(X) Got class = class com.sun.prism.es2.ES2Pipeline
Failed Graphics Hardware Qualifier check.
System GPU doesn't meet the es2 pipe requirement
GraphicsPipeline.createPipeline: error initializing pipeline com.sun.prism.es2.ES2Pipeline
*** Fallback to Prism SW pipeline
Prism pipeline name = com.sun.prism.sw.SWPipeline
(X) Got class = class com.sun.prism.sw.SWPipeline
Initialized prism pipeline: com.sun.prism.sw.SWPipeline
 vsync: true vpipe: false
Oct 25, 2022 3:42:57 PM javafx.scene.SubScene <init>
WARNING: System can't support ConditionalFeature.SCENE3D
Oct 25, 2022 3:42:57 PM javafx.scene.SubScene <init>
```
I think this is https://bugs.openjdk.org/browse/JDK-8246204 and is fixed with https://github.com/openjdk/jfx/pull/243/commits . Running with a later version of javafx, the issue is solved:

```
Prism pipeline init order: es2 sw 
Using Double Precision Marlin Rasterizer
Using dirty region optimizations
Not using texture mask for primitives
Not forcing power of 2 sizes for textures
Using hardware CLAMP_TO_ZERO mode
Opting in for HiDPI pixel scaling
Prism pipeline name = com.sun.prism.es2.ES2Pipeline
Loading ES2 native library ... prism_es2
	succeeded.
GLFactory using com.sun.prism.es2.X11GLFactory
(X) Got class = class com.sun.prism.es2.ES2Pipeline
Initialized prism pipeline: com.sun.prism.es2.ES2Pipeline
Maximum supported texture size: 16384
Maximum texture size clamped to 4096
Non power of two texture support = true
Maximum number of vertex attributes = 16
Maximum number of uniform vertex components = 16384
Maximum number of uniform fragment components = 16384
Maximum number of varying components = 128
Maximum number of texture units usable in a vertex shader = 32
Maximum number of texture units usable in a fragment shader = 32
Graphics Vendor: Intel
       Renderer: Mesa Intel(R) HD Graphics 530 (SKL GT2)
        Version: 4.6 (Compatibility Profile) Mesa 22.0.5
 vsync: true vpipe: true
ES2ResourceFactory: Prism - createStockShader: FillPgram_Color_AlphaTest.frag
ES2ResourceFactory: Prism - createStockShader: Solid_TextureRGB_AlphaTest.frag
ES2ResourceFactory: Prism - createStockShader: FillPgram_Color.frag
ES2ResourceFactory: Prism - createStockShader: Solid_Color.frag
ES2ResourceFactory: Prism - createStockShader: Solid_TextureRGB.frag
new alphas with length = 4096
ES2ResourceFactory: Prism - createStockShader: Texture_Color_AlphaTest.frag
```